### PR TITLE
Fix lack of animation when frame's size changes

### DIFF
--- a/NXTSegmentedControl/NXTSegmentedControl.m
+++ b/NXTSegmentedControl/NXTSegmentedControl.m
@@ -379,6 +379,7 @@ static const NSTimeInterval kNXTSegmentedControlDefaultAnimationDuration = 0.10f
     UILabel *label = [UILabel new];
     label.textColor = textColor;
     label.text = title;
+    label.contentMode = UIViewContentModeCenter;
     label.textAlignment = NSTextAlignmentCenter;
     label.font = [UIFont systemFontOfSize:13];
     


### PR DESCRIPTION
A really small change, fixes an animation glitch during resizing.

Before:
![nxt_before](https://cloud.githubusercontent.com/assets/197767/23557973/3ac7b65e-0032-11e7-8768-02f5a6ecd026.gif)

After:
![nxt_after](https://cloud.githubusercontent.com/assets/197767/23557979/3f33f73e-0032-11e7-815a-17a66274c901.gif)
